### PR TITLE
cm: Remove libphonenumbergoogle

### DIFF
--- a/snippets/cm.xml
+++ b/snippets/cm.xml
@@ -11,7 +11,6 @@
   <project path="external/htop" name="LineageOS/android_external_htop" />
   <project path="external/koush/ion" name="LineageOS/ion" />
   <project path="external/libncurses" name="LineageOS/android_external_libncurses" />
-  <project path="external/libphonenumbergoogle" name="LineageOS/android_external_libphonenumbergoogle" />
   <project path="external/libtar" name="LineageOS/android_external_libtar" />
   <project path="external/libtruezip" name="LineageOS/android_external_libtruezip" />
   <project path="external/lzo" name="LineageOS/android_external_lzo" />


### PR DESCRIPTION
* It was only used by TextSecure, which is long deprecated

Change-Id: I334cb25c240351b47f9337b99c1e8e3f53401af9